### PR TITLE
Fix: Memperbaiki data surat dan notulen yang tidak tersimpan

### DIFF
--- a/admin/notulen.php
+++ b/admin/notulen.php
@@ -31,6 +31,22 @@ if (!$result) {
 }
 ?>
 
+<?php
+// Tampilkan pesan sukses atau error jika ada
+if (isset($_GET['success'])) {
+    echo '<div class="alert alert-success alert-dismissible fade show" role="alert">';
+    echo htmlspecialchars($_GET['success']);
+    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+    echo '</div>';
+}
+if (isset($_GET['error'])) {
+    echo '<div class="alert alert-danger alert-dismissible fade show" role="alert">';
+    echo htmlspecialchars($_GET['error']);
+    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+    echo '</div>';
+}
+?>
+
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
     <h1 class="h2">Daftar Notulen</h1>
 </div>

--- a/admin/surat_keluar.php
+++ b/admin/surat_keluar.php
@@ -31,6 +31,22 @@ if (!$result) {
 }
 ?>
 
+<?php
+// Tampilkan pesan sukses atau error jika ada
+if (isset($_GET['success'])) {
+    echo '<div class="alert alert-success alert-dismissible fade show" role="alert">';
+    echo htmlspecialchars($_GET['success']);
+    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+    echo '</div>';
+}
+if (isset($_GET['error'])) {
+    echo '<div class="alert alert-danger alert-dismissible fade show" role="alert">';
+    echo htmlspecialchars($_GET['error']);
+    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+    echo '</div>';
+}
+?>
+
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
     <h1 class="h2">Surat Keluar</h1>
 </div>

--- a/admin/surat_masuk.php
+++ b/admin/surat_masuk.php
@@ -31,6 +31,22 @@ if (!$result) {
 }
 ?>
 
+<?php
+// Tampilkan pesan sukses atau error jika ada
+if (isset($_GET['success'])) {
+    echo '<div class="alert alert-success alert-dismissible fade show" role="alert">';
+    echo htmlspecialchars($_GET['success']);
+    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+    echo '</div>';
+}
+if (isset($_GET['error'])) {
+    echo '<div class="alert alert-danger alert-dismissible fade show" role="alert">';
+    echo htmlspecialchars($_GET['error']);
+    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+    echo '</div>';
+}
+?>
+
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
     <h1 class="h2">Surat Masuk</h1>
 </div>


### PR DESCRIPTION
Masalah ini disebabkan oleh dua faktor:
1. Direktori `uploads/` yang diperlukan untuk menyimpan file yang diunggah tidak ada. Hal ini menyebabkan skrip `*_aksi.php` gagal secara diam-diam sebelum data dapat dimasukkan ke database.
2. Antarmuka pengguna tidak menampilkan pesan kesalahan atau keberhasilan dari backend, sehingga pengguna tidak tahu mengapa operasi gagal.

Perbaikan ini mencakup:
- Membuat direktori `uploads/` beserta subdirektori `notulen`, `surat_masuk`, dan `surat_keluar`.
- Menambahkan kode ke halaman `notulen.php`, `surat_masuk.php`, dan `surat_keluar.php` untuk menampilkan pesan status (sukses/error) yang dikirim dari backend.